### PR TITLE
Cleanup: IWYU headers, SigNum -> Signum

### DIFF
--- a/icu4c/source/i18n/complexunitsconverter.cpp
+++ b/icu4c/source/i18n/complexunitsconverter.cpp
@@ -6,13 +6,15 @@
 #if !UCONFIG_NO_FORMATTING
 
 #include <math.h>
-#include <utility>
 
 #include "cmemory.h"
 #include "complexunitsconverter.h"
 #include "uassert.h"
 #include "unicode/fmtable.h"
+#include "unicode/localpointer.h" // for LocalArray
+#include "unicode/measure.h"      // for Measure
 #include "unitconverter.h"
+#include <stdint.h> // for int32_t, int64_t
 
 U_NAMESPACE_BEGIN
 namespace units {

--- a/icu4c/source/i18n/complexunitsconverter.cpp
+++ b/icu4c/source/i18n/complexunitsconverter.cpp
@@ -14,7 +14,6 @@
 #include "unicode/localpointer.h" // for LocalArray
 #include "unicode/measure.h"      // for Measure
 #include "unitconverter.h"
-#include <stdint.h> // for int32_t, int64_t
 
 U_NAMESPACE_BEGIN
 namespace units {

--- a/icu4c/source/i18n/complexunitsconverter.cpp
+++ b/icu4c/source/i18n/complexunitsconverter.cpp
@@ -11,8 +11,8 @@
 #include "complexunitsconverter.h"
 #include "uassert.h"
 #include "unicode/fmtable.h"
-#include "unicode/localpointer.h" // for LocalArray
-#include "unicode/measure.h"      // for Measure
+#include "unicode/localpointer.h"
+#include "unicode/measure.h"
 #include "unitconverter.h"
 
 U_NAMESPACE_BEGIN

--- a/icu4c/source/i18n/complexunitsconverter.h
+++ b/icu4c/source/i18n/complexunitsconverter.h
@@ -8,13 +8,15 @@
 #define __COMPLEXUNITSCONVERTER_H__
 
 #include "cmemory.h"
-#include "unicode/errorcode.h"
 #include "unicode/measunit.h"
-#include "unicode/measure.h"
 #include "unitconverter.h"
 #include "unitsdata.h"
 
 U_NAMESPACE_BEGIN
+
+// Forward declarations
+class Measure;
+
 namespace units {
 
 /**

--- a/icu4c/source/i18n/number_usageprefs.cpp
+++ b/icu4c/source/i18n/number_usageprefs.cpp
@@ -4,18 +4,18 @@
 #if !UCONFIG_NO_FORMATTING
 
 #include "number_usageprefs.h"
-#include "cstring.h" // for uprv_strncpy
+#include "cstring.h"
 #include "number_decimalquantity.h"
 #include "number_microprops.h"
-#include "number_roundingutils.h" // for RoundingImpl
-#include "unicode/char16ptr.h"    // for ConstChar16Ptr
-#include "unicode/currunit.h"     // for CurrencyUnit
-#include "unicode/fmtable.h"      // for Formattable, impl, number
-#include "unicode/measure.h"      // for Measure
+#include "number_roundingutils.h"
+#include "unicode/char16ptr.h"
+#include "unicode/currunit.h"
+#include "unicode/fmtable.h"
+#include "unicode/measure.h"
 #include "unicode/numberformatter.h"
-#include "unicode/platform.h" // for U_NOEXCEPT
-#include "unicode/unum.h"     // for UNumberFormatRoundingMode
-#include "unicode/urename.h"  // for uprv_free, uprv_malloc
+#include "unicode/platform.h"
+#include "unicode/unum.h"
+#include "unicode/urename.h"
 
 using namespace icu::number;
 using namespace icu::number::impl;

--- a/icu4c/source/i18n/number_usageprefs.cpp
+++ b/icu4c/source/i18n/number_usageprefs.cpp
@@ -4,9 +4,18 @@
 #if !UCONFIG_NO_FORMATTING
 
 #include "number_usageprefs.h"
+#include "cstring.h" // for uprv_strncpy
 #include "number_decimalquantity.h"
 #include "number_microprops.h"
+#include "number_roundingutils.h" // for RoundingImpl
+#include "unicode/char16ptr.h"    // for ConstChar16Ptr
+#include "unicode/currunit.h"     // for CurrencyUnit
+#include "unicode/fmtable.h"      // for Formattable, impl, number
+#include "unicode/measure.h"      // for Measure
 #include "unicode/numberformatter.h"
+#include "unicode/platform.h" // for U_NOEXCEPT
+#include "unicode/unum.h"     // for UNumberFormatRoundingMode
+#include "unicode/urename.h"  // for uprv_free, uprv_malloc
 
 using namespace icu::number;
 using namespace icu::number::impl;

--- a/icu4c/source/i18n/number_usageprefs.h
+++ b/icu4c/source/i18n/number_usageprefs.h
@@ -1,7 +1,7 @@
 // © 2020 and later: Unicode, Inc. and others.
 // License & terms of use: http://www.unicode.org/copyright.html
 
-#include "unicode/utypes.h" // for UErrorCode, U_I18N_API
+#include "unicode/utypes.h"
 
 #if !UCONFIG_NO_FORMATTING
 #ifndef __NUMBER_USAGEPREFS_H__
@@ -9,10 +9,10 @@
 
 #include "cmemory.h"
 #include "number_types.h"
-#include "unicode/locid.h"       // for Locale
-#include "unicode/measunit.h"    // for MeasureUnit
-#include "unicode/stringpiece.h" // for StringPiece
-#include "unicode/uobject.h"     // for UMemory
+#include "unicode/locid.h"
+#include "unicode/measunit.h"
+#include "unicode/stringpiece.h"
+#include "unicode/uobject.h"
 #include "unitsrouter.h"
 
 U_NAMESPACE_BEGIN

--- a/icu4c/source/i18n/number_usageprefs.h
+++ b/icu4c/source/i18n/number_usageprefs.h
@@ -1,12 +1,18 @@
 // © 2020 and later: Unicode, Inc. and others.
 // License & terms of use: http://www.unicode.org/copyright.html
 
+#include "unicode/utypes.h" // for UErrorCode, U_I18N_API
+
 #if !UCONFIG_NO_FORMATTING
 #ifndef __NUMBER_USAGEPREFS_H__
 #define __NUMBER_USAGEPREFS_H__
 
 #include "cmemory.h"
 #include "number_types.h"
+#include "unicode/locid.h"       // for Locale
+#include "unicode/measunit.h"    // for MeasureUnit
+#include "unicode/stringpiece.h" // for StringPiece
+#include "unicode/uobject.h"     // for UMemory
 #include "unitsrouter.h"
 
 U_NAMESPACE_BEGIN

--- a/icu4c/source/i18n/unitconverter.cpp
+++ b/icu4c/source/i18n/unitconverter.cpp
@@ -16,7 +16,6 @@
 #include "unitconverter.h"
 #include <algorithm> // for max
 #include <cmath>
-#include <cstdint>  // for int32_t, int8_t
 #include <stdlib.h> // for abs
 #include <utility>  // for swap
 

--- a/icu4c/source/i18n/unitconverter.cpp
+++ b/icu4c/source/i18n/unitconverter.cpp
@@ -6,18 +6,18 @@
 #if !UCONFIG_NO_FORMATTING
 
 #include "charstr.h"
-#include "cmemory.h"                            // for MaybeStackVector
-#include "double-conversion-string-to-double.h" // for StringToDoubleConverter
+#include "cmemory.h"
+#include "double-conversion-string-to-double.h"
 #include "measunit_impl.h"
-#include "uassert.h"              // for U_ASSERT
-#include "unicode/localpointer.h" // for LocalArray
+#include "uassert.h"
+#include "unicode/localpointer.h"
 #include "unicode/measunit.h"
 #include "unicode/stringpiece.h"
 #include "unitconverter.h"
-#include <algorithm> // for max
+#include <algorithm>
 #include <cmath>
-#include <stdlib.h> // for abs
-#include <utility>  // for swap
+#include <stdlib.h>
+#include <utility>
 
 U_NAMESPACE_BEGIN
 namespace units {

--- a/icu4c/source/i18n/unitconverter.cpp
+++ b/icu4c/source/i18n/unitconverter.cpp
@@ -100,10 +100,10 @@ void Factor::substituteConstants() {
         }
 
         auto absPower = std::abs(this->constants[i]);
-        SigNum powerSig = this->constants[i] < 0 ? SigNum::NEGATIVE : SigNum::POSITIVE;
+        Signum powerSig = this->constants[i] < 0 ? Signum::NEGATIVE : Signum::POSITIVE;
         double absConstantValue = std::pow(constantsValues[i], absPower);
 
-        if (powerSig == SigNum::NEGATIVE) {
+        if (powerSig == Signum::NEGATIVE) {
             this->factorDen *= absConstantValue;
         } else {
             this->factorNum *= absConstantValue;
@@ -157,7 +157,7 @@ double strHasDivideSignToDouble(StringPiece strWithDivide, UErrorCode &status) {
   Adds single factor to a `Factor` object. Single factor means "23^2", "23.3333", "ft2m^3" ...etc.
   However, complex factor are not included, such as "ft2m^3*200/3"
 */
-void addFactorElement(Factor &factor, StringPiece elementStr, SigNum sigNum, UErrorCode &status) {
+void addFactorElement(Factor &factor, StringPiece elementStr, Signum signum, UErrorCode &status) {
     StringPiece baseStr;
     StringPiece powerStr;
     int32_t power =
@@ -182,7 +182,7 @@ void addFactorElement(Factor &factor, StringPiece elementStr, SigNum sigNum, UEr
         baseStr = elementStr;
     }
 
-    addSingleFactorConstant(baseStr, power, sigNum, factor, status);
+    addSingleFactorConstant(baseStr, power, signum, factor, status);
 }
 
 /*
@@ -190,21 +190,21 @@ void addFactorElement(Factor &factor, StringPiece elementStr, SigNum sigNum, UEr
  */
 Factor extractFactorConversions(StringPiece stringFactor, UErrorCode &status) {
     Factor result;
-    SigNum sigNum = SigNum::POSITIVE;
+    Signum signum = Signum::POSITIVE;
     auto factorData = stringFactor.data();
     for (int32_t i = 0, start = 0, n = stringFactor.length(); i < n; i++) {
         if (factorData[i] == '*' || factorData[i] == '/') {
             StringPiece factorElement = stringFactor.substr(start, i - start);
-            addFactorElement(result, factorElement, sigNum, status);
+            addFactorElement(result, factorElement, signum, status);
 
             start = i + 1; // Set `start` to point to the start of the new element.
         } else if (i == n - 1) {
             // Last element
-            addFactorElement(result, stringFactor.substr(start, i + 1), sigNum, status);
+            addFactorElement(result, stringFactor.substr(start, i + 1), signum, status);
         }
 
         if (factorData[i] == '/') {
-            sigNum = SigNum::NEGATIVE; // Change the sigNum because we reached the Denominator.
+            signum = Signum::NEGATIVE; // Change the signum because we reached the Denominator.
         }
     }
 
@@ -318,34 +318,34 @@ void loadConversionRate(ConversionRate &conversionRate, const MeasureUnit &sourc
 
 } // namespace
 
-void U_I18N_API addSingleFactorConstant(StringPiece baseStr, int32_t power, SigNum sigNum,
+void U_I18N_API addSingleFactorConstant(StringPiece baseStr, int32_t power, Signum signum,
                                         Factor &factor, UErrorCode &status) {
 
     if (baseStr == "ft_to_m") {
-        factor.constants[CONSTANT_FT2M] += power * sigNum;
+        factor.constants[CONSTANT_FT2M] += power * signum;
     } else if (baseStr == "ft2_to_m2") {
-        factor.constants[CONSTANT_FT2M] += 2 * power * sigNum;
+        factor.constants[CONSTANT_FT2M] += 2 * power * signum;
     } else if (baseStr == "ft3_to_m3") {
-        factor.constants[CONSTANT_FT2M] += 3 * power * sigNum;
+        factor.constants[CONSTANT_FT2M] += 3 * power * signum;
     } else if (baseStr == "in3_to_m3") {
-        factor.constants[CONSTANT_FT2M] += 3 * power * sigNum;
+        factor.constants[CONSTANT_FT2M] += 3 * power * signum;
         factor.factorDen *= 12 * 12 * 12;
     } else if (baseStr == "gal_to_m3") {
         factor.factorNum *= 231;
-        factor.constants[CONSTANT_FT2M] += 3 * power * sigNum;
+        factor.constants[CONSTANT_FT2M] += 3 * power * signum;
         factor.factorDen *= 12 * 12 * 12;
     } else if (baseStr == "gal_imp_to_m3") {
-        factor.constants[CONSTANT_GAL_IMP2M3] += power * sigNum;
+        factor.constants[CONSTANT_GAL_IMP2M3] += power * signum;
     } else if (baseStr == "G") {
-        factor.constants[CONSTANT_G] += power * sigNum;
+        factor.constants[CONSTANT_G] += power * signum;
     } else if (baseStr == "gravity") {
-        factor.constants[CONSTANT_GRAVITY] += power * sigNum;
+        factor.constants[CONSTANT_GRAVITY] += power * signum;
     } else if (baseStr == "lb_to_kg") {
-        factor.constants[CONSTANT_LB2KG] += power * sigNum;
+        factor.constants[CONSTANT_LB2KG] += power * signum;
     } else if (baseStr == "PI") {
-        factor.constants[CONSTANT_PI] += power * sigNum;
+        factor.constants[CONSTANT_PI] += power * signum;
     } else {
-        if (sigNum == SigNum::NEGATIVE) {
+        if (signum == Signum::NEGATIVE) {
             factor.factorDen *= std::pow(strToDouble(baseStr, status), power);
         } else {
             factor.factorNum *= std::pow(strToDouble(baseStr, status), power);

--- a/icu4c/source/i18n/unitconverter.cpp
+++ b/icu4c/source/i18n/unitconverter.cpp
@@ -5,15 +5,20 @@
 
 #if !UCONFIG_NO_FORMATTING
 
-#include <cmath>
-
 #include "charstr.h"
-#include "double-conversion.h"
+#include "cmemory.h"                            // for MaybeStackVector
+#include "double-conversion-string-to-double.h" // for StringToDoubleConverter
 #include "measunit_impl.h"
-#include "unicode/errorcode.h"
+#include "uassert.h"              // for U_ASSERT
+#include "unicode/localpointer.h" // for LocalArray
 #include "unicode/measunit.h"
 #include "unicode/stringpiece.h"
 #include "unitconverter.h"
+#include <algorithm> // for max
+#include <cmath>
+#include <cstdint>  // for int32_t, int8_t
+#include <stdlib.h> // for abs
+#include <utility>  // for swap
 
 U_NAMESPACE_BEGIN
 namespace units {

--- a/icu4c/source/i18n/unitconverter.h
+++ b/icu4c/source/i18n/unitconverter.h
@@ -11,7 +11,6 @@
 #include "unicode/stringpiece.h" // for StringPiece
 #include "unicode/uobject.h"     // for UMemory
 #include "unitsdata.h"
-#include <stdint.h> // for int32_t
 
 U_NAMESPACE_BEGIN
 namespace units {

--- a/icu4c/source/i18n/unitconverter.h
+++ b/icu4c/source/i18n/unitconverter.h
@@ -8,8 +8,8 @@
 #define __UNITCONVERTER_H__
 
 #include "unicode/measunit.h"
-#include "unicode/stringpiece.h" // for StringPiece
-#include "unicode/uobject.h"     // for UMemory
+#include "unicode/stringpiece.h"
+#include "unicode/uobject.h"
 #include "unitsdata.h"
 
 U_NAMESPACE_BEGIN

--- a/icu4c/source/i18n/unitconverter.h
+++ b/icu4c/source/i18n/unitconverter.h
@@ -30,10 +30,10 @@ enum Constants {
     CONSTANTS_COUNT
 };
 
-typedef enum SigNum {
+typedef enum Signum {
     NEGATIVE = -1,
     POSITIVE = 1,
-} SigNum;
+} Signum;
 
 /* Represents a conversion factor */
 struct Factor {
@@ -60,7 +60,7 @@ struct Factor {
 /*
  * Adds a single factor element to the `Factor`. e.g "ft3m", "2.333" or "cup2m3". But not "cup2m3^3".
  */
-void U_I18N_API addSingleFactorConstant(StringPiece baseStr, int32_t power, SigNum sigNum,
+void U_I18N_API addSingleFactorConstant(StringPiece baseStr, int32_t power, Signum sigNum,
                                         Factor &factor, UErrorCode &status);
 
 /**

--- a/icu4c/source/i18n/unitconverter.h
+++ b/icu4c/source/i18n/unitconverter.h
@@ -7,11 +7,11 @@
 #ifndef __UNITCONVERTER_H__
 #define __UNITCONVERTER_H__
 
-#include "cmemory.h"
-#include "unicode/errorcode.h"
 #include "unicode/measunit.h"
-#include "unitconverter.h"
+#include "unicode/stringpiece.h" // for StringPiece
+#include "unicode/uobject.h"     // for UMemory
 #include "unitsdata.h"
+#include <stdint.h> // for int32_t
 
 U_NAMESPACE_BEGIN
 namespace units {

--- a/icu4c/source/i18n/unitsdata.cpp
+++ b/icu4c/source/i18n/unitsdata.cpp
@@ -5,13 +5,16 @@
 
 #if !UCONFIG_NO_FORMATTING
 
-#include "number_decimalquantity.h"
 #include "cstring.h"
 #include "number_decimalquantity.h"
 #include "resource.h"
+#include "uassert.h"        // for U_ASSERT
+#include "unicode/unistr.h" // for UnicodeString
+#include "unicode/ures.h"   // for LocalUResourceBundlePointer, ure...
 #include "unitsdata.h"
 #include "uresimp.h"
 #include "util.h"
+#include <utility> // for move
 
 U_NAMESPACE_BEGIN
 namespace units {

--- a/icu4c/source/i18n/unitsdata.cpp
+++ b/icu4c/source/i18n/unitsdata.cpp
@@ -8,13 +8,13 @@
 #include "cstring.h"
 #include "number_decimalquantity.h"
 #include "resource.h"
-#include "uassert.h"        // for U_ASSERT
-#include "unicode/unistr.h" // for UnicodeString
-#include "unicode/ures.h"   // for LocalUResourceBundlePointer, ure...
+#include "uassert.h"
+#include "unicode/unistr.h"
+#include "unicode/ures.h"
 #include "unitsdata.h"
 #include "uresimp.h"
 #include "util.h"
-#include <utility> // for move
+#include <utility>
 
 U_NAMESPACE_BEGIN
 namespace units {

--- a/icu4c/source/i18n/unitsdata.h
+++ b/icu4c/source/i18n/unitsdata.h
@@ -10,7 +10,7 @@
 #include "charstr.h"
 #include "cmemory.h"
 #include "unicode/stringpiece.h"
-#include "unicode/uobject.h" // for UMemory
+#include "unicode/uobject.h"
 
 U_NAMESPACE_BEGIN
 namespace units {

--- a/icu4c/source/i18n/unitsdata.h
+++ b/icu4c/source/i18n/unitsdata.h
@@ -9,8 +9,9 @@
 
 #include "charstr.h"
 #include "cmemory.h"
-#include "unicode/measunit.h"
 #include "unicode/stringpiece.h"
+#include "unicode/uobject.h" // for UMemory
+#include <stdint.h>          // for int32_t
 
 U_NAMESPACE_BEGIN
 namespace units {

--- a/icu4c/source/i18n/unitsdata.h
+++ b/icu4c/source/i18n/unitsdata.h
@@ -11,7 +11,6 @@
 #include "cmemory.h"
 #include "unicode/stringpiece.h"
 #include "unicode/uobject.h" // for UMemory
-#include <stdint.h>          // for int32_t
 
 U_NAMESPACE_BEGIN
 namespace units {

--- a/icu4c/source/i18n/unitsrouter.cpp
+++ b/icu4c/source/i18n/unitsrouter.cpp
@@ -5,17 +5,13 @@
 
 #if !UCONFIG_NO_FORMATTING
 
-#include <stdio.h>
-#include <utility>
-
+#include "charstr.h" // for CharString
 #include "cmemory.h"
-#include "cstring.h"
-#include "number_decimalquantity.h"
-#include "resource.h"
+#include "unicode/measure.h" // for Measure
 #include "unitconverter.h" // for extractCompoundBaseUnit
 #include "unitsdata.h"     // for getUnitCategory
 #include "unitsrouter.h"
-#include "uresimp.h"
+#include <stdint.h> // for int32_t
 
 U_NAMESPACE_BEGIN
 namespace units {

--- a/icu4c/source/i18n/unitsrouter.cpp
+++ b/icu4c/source/i18n/unitsrouter.cpp
@@ -11,7 +11,6 @@
 #include "unitconverter.h" // for extractCompoundBaseUnit
 #include "unitsdata.h"     // for getUnitCategory
 #include "unitsrouter.h"
-#include <stdint.h> // for int32_t
 
 U_NAMESPACE_BEGIN
 namespace units {

--- a/icu4c/source/i18n/unitsrouter.cpp
+++ b/icu4c/source/i18n/unitsrouter.cpp
@@ -5,11 +5,11 @@
 
 #if !UCONFIG_NO_FORMATTING
 
-#include "charstr.h" // for CharString
+#include "charstr.h"
 #include "cmemory.h"
-#include "unicode/measure.h" // for Measure
-#include "unitconverter.h" // for extractCompoundBaseUnit
-#include "unitsdata.h"     // for getUnitCategory
+#include "unicode/measure.h"
+#include "unitconverter.h"
+#include "unitsdata.h"
 #include "unitsrouter.h"
 
 U_NAMESPACE_BEGIN

--- a/icu4c/source/i18n/unitsrouter.h
+++ b/icu4c/source/i18n/unitsrouter.h
@@ -13,7 +13,7 @@
 #include "complexunitsconverter.h"
 #include "unicode/measunit.h"
 #include "unicode/stringpiece.h"
-#include "unicode/uobject.h" // for UMemory
+#include "unicode/uobject.h"
 #include "unitsdata.h"
 
 U_NAMESPACE_BEGIN

--- a/icu4c/source/i18n/unitsrouter.h
+++ b/icu4c/source/i18n/unitsrouter.h
@@ -9,16 +9,18 @@
 
 #include <limits>
 
-#include "charstr.h" // CharString
 #include "cmemory.h"
 #include "complexunitsconverter.h"
-#include "unicode/errorcode.h"
 #include "unicode/measunit.h"
-#include "unicode/measure.h"
 #include "unicode/stringpiece.h"
+#include "unicode/uobject.h" // for UMemory
 #include "unitsdata.h"
 
 U_NAMESPACE_BEGIN
+
+// Forward declarations
+class Measure;
+
 namespace units {
 
 /**


### PR DESCRIPTION
I noticed an issue or two with headers / includes, so I ran IWYU against the units-related code and updated the includes accordingly.

How do we feel about IWYU in ICU4C? And the "why comments", which I've now added inconsistently? (--no_comments might be cleaner.)

Here's my commit message for the IWYU edits:

    Follow IWYU recommendations with only a couple of exceptions:
    
    Exceptions:
    - uconfig.h, umachine.h, uversion.h (included via utypes.h)
    - urename.h, stddef.h (included via umachine.h, thus utypes.h)
    - a couple of forward declarations, where transitive includes take
      care of it (number_usageprefs.h: DecimalQuantity, MicroProps).

I'm wondering whether includes might differ from platform to platform...

And strangely, somehow IWYU missed a "pow", suggesting removal of a "cmath" include without which the code doesn't compile.

<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [ ] Issue filed: https://unicode-org.atlassian.net/browse/ICU-_____
- [ ] Updated PR title and link in previous line to include Issue number
- [ ] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

