### PR TITLE
Test that addSingleFactorConstant knowns all unitConstants.

### DIFF
--- a/icu4c/source/data/misc/units.txt
+++ b/icu4c/source/data/misc/units.txt
@@ -425,6 +425,7 @@ units:table(nofallback){
         gravity{"9.80665"}
         in3_to_m3{"ft3_to_m3/12*12*12"}
         lb_to_kg{"0.45359237"}
+        foobar{"1.234"}
     }
     unitPreferenceData{
         "area"{

--- a/icu4c/source/data/misc/units.txt
+++ b/icu4c/source/data/misc/units.txt
@@ -425,7 +425,6 @@ units:table(nofallback){
         gravity{"9.80665"}
         in3_to_m3{"ft3_to_m3/12*12*12"}
         lb_to_kg{"0.45359237"}
-        foobar{"1.234"}
     }
     unitPreferenceData{
         "area"{

--- a/icu4c/source/i18n/unitconverter.cpp
+++ b/icu4c/source/i18n/unitconverter.cpp
@@ -318,9 +318,12 @@ void loadConversionRate(ConversionRate &conversionRate, const MeasureUnit &sourc
 
 } // namespace
 
+// Conceptually, this modifies factor: factor *= baseStr^(signum*power).
+//
+// baseStr must be a known constant or a value that strToDouble() is able to
+// parse.
 void U_I18N_API addSingleFactorConstant(StringPiece baseStr, int32_t power, SigNum sigNum,
                                         Factor &factor, UErrorCode &status) {
-
     if (baseStr == "ft_to_m") {
         factor.constants[CONSTANT_FT2M] += power * sigNum;
     } else if (baseStr == "ft2_to_m2") {

--- a/icu4c/source/i18n/unitconverter.cpp
+++ b/icu4c/source/i18n/unitconverter.cpp
@@ -84,15 +84,19 @@ void Factor::applySiPrefix(UMeasureSIPrefix siPrefix) {
 }
 
 void Factor::substituteConstants() {
-    double constantsValues[CONSTANTS_COUNT];
-
-    // TODO: Load those constant values from units data.
-    constantsValues[CONSTANT_FT2M] = 0.3048;
-    constantsValues[CONSTANT_PI] = 411557987.0 / 131002976.0;
-    constantsValues[CONSTANT_GRAVITY] = 9.80665;
-    constantsValues[CONSTANT_G] = 6.67408E-11;
-    constantsValues[CONSTANT_LB2KG] = 0.45359237;
-    constantsValues[CONSTANT_GAL_IMP2M3] = 0.00454609;
+    // These values are a hard-coded subset of unitConstants in the units
+    // resources file. A unit test checks that all constants in the resource
+    // file are at least recognised by the code. Derived constants' values or
+    // hard-coded derivations are not checked.
+    // double constantsValues[CONSTANTS_COUNT];
+    static const double constantsValues[CONSTANTS_COUNT] = {
+        [CONSTANT_FT2M] = 0.3048,                  //
+        [CONSTANT_PI] = 411557987.0 / 131002976.0, //
+        [CONSTANT_GRAVITY] = 9.80665,              //
+        [CONSTANT_G] = 6.67408E-11,                //
+        [CONSTANT_GAL_IMP2M3] = 0.00454609,        //
+        [CONSTANT_LB2KG] = 0.45359237,             //
+    };
 
     for (int i = 0; i < CONSTANTS_COUNT; i++) {
         if (this->constants[i] == 0) {

--- a/icu4c/source/i18n/unitconverter.cpp
+++ b/icu4c/source/i18n/unitconverter.cpp
@@ -18,7 +18,7 @@
 U_NAMESPACE_BEGIN
 namespace units {
 
-void Factor::multiplyBy(const Factor &rhs) {
+void U_I18N_API Factor::multiplyBy(const Factor &rhs) {
     factorNum *= rhs.factorNum;
     factorDen *= rhs.factorDen;
     for (int i = 0; i < CONSTANTS_COUNT; i++) {
@@ -31,7 +31,7 @@ void Factor::multiplyBy(const Factor &rhs) {
     offset = std::max(rhs.offset, offset);
 }
 
-void Factor::divideBy(const Factor &rhs) {
+void U_I18N_API Factor::divideBy(const Factor &rhs) {
     factorNum *= rhs.factorDen;
     factorDen *= rhs.factorNum;
     for (int i = 0; i < CONSTANTS_COUNT; i++) {
@@ -44,7 +44,7 @@ void Factor::divideBy(const Factor &rhs) {
     offset = std::max(rhs.offset, offset);
 }
 
-void Factor::power(int32_t power) {
+void U_I18N_API Factor::power(int32_t power) {
     // multiply all the constant by the power.
     for (int i = 0; i < CONSTANTS_COUNT; i++) {
         constants[i] *= power;
@@ -62,7 +62,7 @@ void Factor::power(int32_t power) {
     }
 }
 
-void Factor::flip() {
+void U_I18N_API Factor::flip() {
     std::swap(factorNum, factorDen);
 
     for (int i = 0; i < CONSTANTS_COUNT; i++) {
@@ -70,7 +70,7 @@ void Factor::flip() {
     }
 }
 
-void Factor::applySiPrefix(UMeasureSIPrefix siPrefix) {
+void U_I18N_API Factor::applySiPrefix(UMeasureSIPrefix siPrefix) {
     if (siPrefix == UMeasureSIPrefix::UMEASURE_SI_PREFIX_ONE) return; // No need to do anything
 
     double siApplied = std::pow(10.0, std::abs(siPrefix));
@@ -83,7 +83,7 @@ void Factor::applySiPrefix(UMeasureSIPrefix siPrefix) {
     factorNum *= siApplied;
 }
 
-void Factor::substituteConstants() {
+void U_I18N_API Factor::substituteConstants() {
     // These values are a hard-coded subset of unitConstants in the units
     // resources file. A unit test checks that all constants in the resource
     // file are at least recognised by the code. Derived constants' values or

--- a/icu4c/source/i18n/unitconverter.h
+++ b/icu4c/source/i18n/unitconverter.h
@@ -36,7 +36,7 @@ typedef enum SigNum {
 } SigNum;
 
 /* Represents a conversion factor */
-struct Factor {
+struct U_I18N_API Factor {
     double factorNum = 1;
     double factorDen = 1;
     double offset = 0;

--- a/icu4c/source/test/intltest/unitstest.cpp
+++ b/icu4c/source/test/intltest/unitstest.cpp
@@ -18,10 +18,12 @@
 #include "unicode/measunit.h"
 #include "unicode/unistr.h"
 #include "unicode/unum.h"
+#include "unicode/ures.h"
 #include "unitconverter.h"
 #include "unitsdata.h"
 #include "unitsrouter.h"
 #include "uparse.h"
+#include "uresimp.h"
 
 struct UnitConversionTestCase {
     const StringPiece source;
@@ -39,6 +41,7 @@ class UnitsTest : public IntlTest {
 
     void runIndexedTest(int32_t index, UBool exec, const char *&name, char *par = NULL);
 
+    void testHardcodeFreshnessForConvertUnits();
     void testConversionCapability();
     void testConversions();
     void testPreferences();
@@ -55,6 +58,7 @@ void UnitsTest::runIndexedTest(int32_t index, UBool exec, const char *&name, cha
         logln("TestSuite UnitsTest: ");
     }
     TESTCASE_AUTO_BEGIN;
+    TESTCASE_AUTO(testHardcodeFreshnessForConvertUnits);
     TESTCASE_AUTO(testConversionCapability);
     TESTCASE_AUTO(testConversions);
     TESTCASE_AUTO(testPreferences);
@@ -63,6 +67,77 @@ void UnitsTest::runIndexedTest(int32_t index, UBool exec, const char *&name, cha
     TESTCASE_AUTO(testTemperature);
     TESTCASE_AUTO(testArea);
     TESTCASE_AUTO_END;
+}
+
+// Tests the hard-coded constants in the code against constants and unit
+// identifiers that appear in units.txt, by simply parsing unit identifiers and
+// then loading each conversion rate from the convertUnits resource into
+// UnitConverter.
+//
+// MeasureUnit::forIdentifier() will fail for invalid unit identifiers.
+//
+// UnitConverter() returns an error if it fails to recognise a constant, which
+// would thereby alert us if the hard-coded constants are stale.
+void UnitsTest::testHardcodeFreshnessForConvertUnits() {
+    IcuTestErrorCode status(*this, "testConstantFreshness");
+    LocalUResourceBundlePointer unitsBundle(ures_openDirect(NULL, "units", status));
+    LocalUResourceBundlePointer unitConstants(
+        ures_getByKey(unitsBundle.getAlias(), "unitConstants", NULL, status));
+    LocalUResourceBundlePointer convertUnits(
+        ures_getByKey(unitsBundle.getAlias(), "convertUnits", NULL, status));
+
+    CharString constants;
+    while (ures_hasNext(unitConstants.getAlias())) {
+        int32_t len;
+        const char *constant = NULL;
+        ures_getNextString(unitConstants.getAlias(), &len, &constant, status);
+        constants.append(" \"", status);
+        constants.append(constant, status);
+        constants.append("\"", status);
+    }
+
+    if (status.errDataIfFailureAndReset("ures_getByKey(unitsBundle, \"convertUnits\", ...)")) {
+        return;
+    }
+    ConversionRates conversionRates(status);
+    StackUResourceBundle stackBundle;
+    while (ures_hasNext(convertUnits.getAlias())) {
+        ures_getNextResource(convertUnits.getAlias(), stackBundle.getAlias(), status);
+        const char *sourceKey = ures_getKey(stackBundle.getAlias());
+
+        int32_t targetLen;
+        const UChar *uTarget = ures_getStringByKey(stackBundle.getAlias(), "target", &targetLen, status);
+        CharString target;
+        target.appendInvariantChars(uTarget, targetLen, status);
+
+        int32_t factorLen;
+        const UChar *uFactor = ures_getStringByKey(stackBundle.getAlias(), "factor", &factorLen, status);
+        CharString factor;
+        factor.appendInvariantChars(uFactor, factorLen, status);
+
+        if (status.errDataIfFailureAndReset("Resource loading failure")) { return; }
+        MeasureUnit sourceUnit = MeasureUnit::forIdentifier(sourceKey, status);
+        MeasureUnit targetUnit = MeasureUnit::forIdentifier(target.data(), status);
+        if (status.errDataIfFailureAndReset(
+                "MeasureUnit::forIdentifier(\"%s\", status); "
+                "MeasureUnit::forIdentifier(\"%s\", status);\n\n"
+                "If U_ILLEGAL_ARGUMENT_ERROR, please check that "
+                "\"icu4c/source/i18n/measunit_extra.cpp\" has the necessary unit identifiers in the "
+                "gSimpleUnits[] array. (Also check the gSubTypes[] array in measunit.cpp?)",
+                sourceKey, target.data())) {
+            continue;
+        }
+        UnitConverter(sourceUnit, targetUnit, conversionRates, status);
+        if (status.errDataIfFailureAndReset(
+                "UnitConverter(<%s>, <%s>, status).\n\n"
+                "If U_INVALID_FORMAT_ERROR, please check that \"icu4c/source/i18n/unitconverter.cpp\" "
+                "has all constants?\n"
+                "Factor for \"%s\" is: \"%s\".\n"
+                "Full list of constants:%s",
+                sourceKey, target.data(), sourceKey, factor.data(), constants.data())) {
+            continue;
+        }
+    }
 }
 
 void UnitsTest::testConversionCapability() {


### PR DESCRIPTION
Example unit test output for a fake new constant "foobar":

         testUnitConstantFreshness {
         testUnitConstantFreshness data: expected success but got error: U_INVALID_FORMAT_ERROR - addSingleFactorConstant(<foobar>, ...).
         
         If U_INVALID_FORMAT_ERROR, please check that "icu4c/source/i18n/unitconverter.cpp" has all constants? Is "foobar" a new constant?
          - (Are you missing data?)
      
         } ERRORS (1) in testUnitConstantFreshness


<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [ ] Issue filed: https://unicode-org.atlassian.net/browse/ICU-_____
- [ ] Updated PR title and link in previous line to include Issue number
- [ ] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

