### PR TITLE
Remove stray 'splitDirs.isEmpty()' check.

### DIFF
--- a/tools/cldr/cldr-to-icu/src/main/java/org/unicode/icu/tool/cldrtoicu/LdmlConverter.java
+++ b/tools/cldr/cldr-to-icu/src/main/java/org/unicode/icu/tool/cldrtoicu/LdmlConverter.java
@@ -283,10 +283,6 @@ public final class LdmlConverter {
 
         String cldrVersion = config.getCldrVersion();
 
-        if (splitDirs.isEmpty()) {
-            return;
-        }
-
         Map<IcuLocaleDir, DependencyGraph> graphMetadata = new HashMap<>();
         splitDirs.forEach(d -> graphMetadata.put(d, new DependencyGraph(cldrVersion)));
 


### PR DESCRIPTION
Small units-staging clean-up: this duplicate check probably came from a dirty merge - it isn't present in upstream.
(All tools/ changes in units-staging have already been upstreamed.)