### PR TITLE
fixup! ICU-21059 Load simple unit IDs from convertUnits.

### DIFF
--- a/icu4c/source/i18n/measunit_extra.cpp
+++ b/icu4c/source/i18n/measunit_extra.cpp
@@ -173,11 +173,11 @@ icu::UInitOnce gUnitExtrasInitOnce = U_INITONCE_INITIALIZER;
 // by SingleUnitImpl::getSimpleUnitID().)
 const char **gSimpleUnits = nullptr;
 
-char *kSerializedUnitExtrasStemTrie = nullptr;
+char *gSerializedUnitExtrasStemTrie = nullptr;
 
 UBool U_CALLCONV cleanupUnitExtras() {
-    uprv_free(kSerializedUnitExtrasStemTrie);
-    kSerializedUnitExtrasStemTrie = nullptr;
+    uprv_free(gSerializedUnitExtrasStemTrie);
+    gSerializedUnitExtrasStemTrie = nullptr;
     uprv_free(gSimpleUnits);
     gSimpleUnits = nullptr;
     gUnitExtrasInitOnce.reset();
@@ -250,12 +250,12 @@ void U_CALLCONV initUnitExtras(UErrorCode& status) {
 
     // Copy the result into the global constant pointer
     size_t numBytes = result.length();
-    kSerializedUnitExtrasStemTrie = static_cast<char *>(uprv_malloc(numBytes));
-    if (kSerializedUnitExtrasStemTrie == nullptr) {
+    gSerializedUnitExtrasStemTrie = static_cast<char *>(uprv_malloc(numBytes));
+    if (gSerializedUnitExtrasStemTrie == nullptr) {
         status = U_MEMORY_ALLOCATION_ERROR;
         return;
     }
-    uprv_memcpy(kSerializedUnitExtrasStemTrie, result.data(), numBytes);
+    uprv_memcpy(gSerializedUnitExtrasStemTrie, result.data(), numBytes);
 }
 
 class Token {
@@ -372,7 +372,7 @@ private:
     Parser() : fSource(""), fTrie(u"") {}
 
     Parser(StringPiece source)
-        : fSource(source), fTrie(kSerializedUnitExtrasStemTrie) {}
+        : fSource(source), fTrie(gSerializedUnitExtrasStemTrie) {}
 
     inline bool hasNext() const {
         return fIndex < fSource.length();


### PR DESCRIPTION
This PR has the additional commit I've pushed in https://github.com/unicode-org/icu/pull/1211 but not in units-staging.

I don't mind too much whether this is merged or not, but it's convenient. My rationale for creating this PR:
- with it, an upstream/master merge is clean; without it, there's a small conflict to resolve.
- squashing this commit into hugovdm_upstreaming (as fixup) will let hugovdm_upstreaming rebase without trouble
  - (and with it squashed into hugovdm_upstreaming but not included in units-staging, there will be a temporary diff between units-staging and hugovdm_upstreaming).

<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [ ] Issue filed: https://unicode-org.atlassian.net/browse/ICU-_____
- [ ] Updated PR title and link in previous line to include Issue number
- [ ] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

