### PR TITLE
Fix double-precision maths in unit conversions

### DIFF
--- a/icu4c/source/i18n/complexunitsconverter.cpp
+++ b/icu4c/source/i18n/complexunitsconverter.cpp
@@ -91,13 +91,15 @@ MaybeStackVector<Measure> ComplexUnitsConverter::convert(double quantity, UError
 
             // Keep the residual of the quantity.
             //   For example: `3.6 feet`, keep only `0.6 feet`
-            quantity -= newQuantity;
-        } else { // LAST ELEMENT
-            if (quantity < 0) {
-                // Because we nudged the bigger units up by epsilon, we might
-                // end up with a negative number here.
+            //
+            // When the calculation is near enough +/- DBL_EPSILON, we round to
+            // zero. (We also ensure no negative values here.)
+            if ((quantity - newQuantity) / quantity < DBL_EPSILON) {
                 quantity = 0;
+            } else {
+                quantity -= newQuantity;
             }
+        } else { // LAST ELEMENT
             Formattable formattableQuantity(quantity);
 
             // NOTE: Measure would own its MeasureUnit.

--- a/icu4c/source/i18n/complexunitsconverter.cpp
+++ b/icu4c/source/i18n/complexunitsconverter.cpp
@@ -95,10 +95,7 @@ MaybeStackVector<Measure> ComplexUnitsConverter::convert(double quantity, UError
         } else { // LAST ELEMENT
             if (quantity < 0) {
                 // Because we nudged the bigger units up by epsilon, we might
-                // end up with a negative number here. This number should be
-                // really tiny. (Unless someone is doing
-                // "light-year-and-nanometer" perhaps?)
-                U_ASSERT(quantity > -1e-6);
+                // end up with a negative number here.
                 quantity = 0;
             }
             Formattable formattableQuantity(quantity);

--- a/icu4c/source/i18n/complexunitsconverter.cpp
+++ b/icu4c/source/i18n/complexunitsconverter.cpp
@@ -75,7 +75,8 @@ MaybeStackVector<Measure> ComplexUnitsConverter::convert(double quantity, UError
     for (int i = 0, n = unitConverters_.length(); i < n; ++i) {
         quantity = (*unitConverters_[i]).convert(quantity);
         if (i < n - 1) {
-            int64_t newQuantity = floor(quantity);
+            // TODO: find a better solution to this threshold-related hack:
+            int64_t newQuantity = floor(quantity * 1.000000000001);
             Formattable formattableNewQuantity(newQuantity);
 
             // NOTE: Measure would own its MeasureUnit.
@@ -91,6 +92,9 @@ MaybeStackVector<Measure> ComplexUnitsConverter::convert(double quantity, UError
             // NOTE: Measure would own its MeasureUnit.
             MeasureUnit *type = new MeasureUnit(units_[i]->copy(status).build(status));
             result.emplaceBackAndCheckErrorCode(status, formattableQuantity, type, status);
+
+            // TODO: add unit tests to trigger negative numbers. Then fix by
+            // checking for negative numbers here and rounding to zero.
         }
     }
 

--- a/icu4c/source/i18n/complexunitsconverter.cpp
+++ b/icu4c/source/i18n/complexunitsconverter.cpp
@@ -70,7 +70,6 @@ UBool ComplexUnitsConverter::greaterThanOrEqual(double quantity, double limit) c
 }
 
 MaybeStackVector<Measure> ComplexUnitsConverter::convert(double quantity, UErrorCode &status) const {
-    constexpr double EPSILON = 1e-12; // Consider using DBL_EPSILON instead?
     MaybeStackVector<Measure> result;
 
     for (int i = 0, n = unitConverters_.length(); i < n; ++i) {
@@ -82,7 +81,7 @@ MaybeStackVector<Measure> ComplexUnitsConverter::convert(double quantity, UError
             // decision is made. However after the thresholding, we use the
             // original values to ensure unbiased accuracy (to the extent of
             // double's capabilities).
-            int64_t newQuantity = floor(quantity * (1 + EPSILON));
+            int64_t newQuantity = floor(quantity * (1 + DBL_EPSILON));
             Formattable formattableNewQuantity(newQuantity);
 
             // NOTE: Measure would own its MeasureUnit.

--- a/icu4c/source/i18n/complexunitsconverter.cpp
+++ b/icu4c/source/i18n/complexunitsconverter.cpp
@@ -82,8 +82,8 @@ MaybeStackVector<Measure> ComplexUnitsConverter::convert(double quantity, UError
             // decision is made. However after the thresholding, we use the
             // original values to ensure unbiased accuracy (to the extent of
             // double's capabilities).
-            int64_t newQuantity = floor(quantity * (1 + DBL_EPSILON));
-            Formattable formattableNewQuantity(newQuantity);
+            int64_t roundedQuantity = floor(quantity * (1 + DBL_EPSILON));
+            Formattable formattableNewQuantity(roundedQuantity);
 
             // NOTE: Measure would own its MeasureUnit.
             MeasureUnit *type = new MeasureUnit(units_[i]->copy(status).build(status));
@@ -94,10 +94,10 @@ MaybeStackVector<Measure> ComplexUnitsConverter::convert(double quantity, UError
             //
             // When the calculation is near enough +/- DBL_EPSILON, we round to
             // zero. (We also ensure no negative values here.)
-            if ((quantity - newQuantity) / quantity < DBL_EPSILON) {
+            if ((quantity - roundedQuantity) / quantity < DBL_EPSILON) {
                 quantity = 0;
             } else {
-                quantity -= newQuantity;
+                quantity -= roundedQuantity;
             }
         } else { // LAST ELEMENT
             Formattable formattableQuantity(quantity);

--- a/icu4c/source/i18n/unitconverter.cpp
+++ b/icu4c/source/i18n/unitconverter.cpp
@@ -516,11 +516,7 @@ double UnitConverter::convert(double inputValue) const {
         result = 1.0 / result;
     }
 
-    // TODO: remove the multiplication by 1.000,000,000,001 after using `decNumber`
-
-    // Multiply the result by 1.000,000,000,001 to fix the deterioration from using `double` (the
-    // deterioration is around 15 to 17 decimal digit).
-    return result * 1.000000000001;
+    return result;
 }
 
 } // namespace units

--- a/icu4c/source/i18n/unitsrouter.cpp
+++ b/icu4c/source/i18n/unitsrouter.cpp
@@ -68,13 +68,10 @@ UnitsRouter::UnitsRouter(MeasureUnit inputUnit, StringPiece region, StringPiece 
 }
 
 RouteResult UnitsRouter::route(double quantity, UErrorCode &status) const {
+    constexpr double EPSILON = 1e-12; // Consider using DBL_EPSILON instead?
     for (int i = 0, n = converterPreferences_.length(); i < n; i++) {
         const auto &converterPreference = *converterPreferences_[i];
-
-        // TODO: add unit tests for just-under-threshold values which still fail
-        // with this threshold tweak - then reconsider cutoffs appropriate for
-        // the rounding/precision in use?
-        if (converterPreference.converter.greaterThanOrEqual(quantity * 1.000000000001,
+        if (converterPreference.converter.greaterThanOrEqual(quantity * (1 + EPSILON),
                                                              converterPreference.limit)) {
             return RouteResult(converterPreference.converter.convert(quantity, status),
                                converterPreference.precision,

--- a/icu4c/source/i18n/unitsrouter.cpp
+++ b/icu4c/source/i18n/unitsrouter.cpp
@@ -68,10 +68,9 @@ UnitsRouter::UnitsRouter(MeasureUnit inputUnit, StringPiece region, StringPiece 
 }
 
 RouteResult UnitsRouter::route(double quantity, UErrorCode &status) const {
-    constexpr double EPSILON = 1e-12; // Consider using DBL_EPSILON instead?
     for (int i = 0, n = converterPreferences_.length(); i < n; i++) {
         const auto &converterPreference = *converterPreferences_[i];
-        if (converterPreference.converter.greaterThanOrEqual(quantity * (1 + EPSILON),
+        if (converterPreference.converter.greaterThanOrEqual(quantity * (1 + DBL_EPSILON),
                                                              converterPreference.limit)) {
             return RouteResult(converterPreference.converter.convert(quantity, status),
                                converterPreference.precision,

--- a/icu4c/source/i18n/unitsrouter.cpp
+++ b/icu4c/source/i18n/unitsrouter.cpp
@@ -71,7 +71,11 @@ RouteResult UnitsRouter::route(double quantity, UErrorCode &status) const {
     for (int i = 0, n = converterPreferences_.length(); i < n; i++) {
         const auto &converterPreference = *converterPreferences_[i];
 
-        if (converterPreference.converter.greaterThanOrEqual(quantity, converterPreference.limit)) {
+        // TODO: add unit tests for just-under-threshold values which still fail
+        // with this threshold tweak - then reconsider cutoffs appropriate for
+        // the rounding/precision in use?
+        if (converterPreference.converter.greaterThanOrEqual(quantity * 1.000000000001,
+                                                             converterPreference.limit)) {
             return RouteResult(converterPreference.converter.convert(quantity, status),
                                converterPreference.precision,
                                converterPreference.targetUnit.copy(status));

--- a/icu4c/source/test/intltest/numbertest_api.cpp
+++ b/icu4c/source/test/intltest/numbertest_api.cpp
@@ -709,7 +709,7 @@ void NumberFormatterApiTest::unitUsage() {
             Locale("en-ZA"),
             u"87\u00A0650 km",
             u"8\u00A0765 km",
-            u"877 km",
+            u"876 km", // 6.5 rounds down, 7.5 rounds up.
             u"88 km",
             u"8,8 km",
             u"900 m",
@@ -989,8 +989,8 @@ void NumberFormatterApiTest::unitUsageSkeletons() {
                 .notation(Notation::scientific())
                 .precision(Precision::maxSignificantDigits(4)),
             Locale("en-ZA"),
-            321.45,
-            u"3,215E2 m");
+            321.45, // 0.45 rounds down, 0.55 rounds up.
+            u"3,214E2 m");
 
     assertFormatSingle(
             u"Scientific notation with Usage: possible when using a reasonable Precision",

--- a/icu4c/source/test/intltest/unitstest.cpp
+++ b/icu4c/source/test/intltest/unitstest.cpp
@@ -458,10 +458,11 @@ void UnitsTest::testComplexUnitConverter() {
     assertEquals("1 - eps: measures[0] value", 2.0, measures2[0]->getNumber().getDouble(status));
     assertEquals("1 - eps: measures[0] unit", MeasureUnit::getFoot().getIdentifier(),
                  measures2[0]->getUnit().getIdentifier());
-    // FIXME: broken value, as demonstration of bad code.
-    assertTrue("1 - eps: measures[1] value", measures2[1]->getNumber().getDouble(status) < 0);
+    assertEquals("1 - eps: measures[1] value", 0.0, measures2[1]->getNumber().getDouble(status));
     assertEquals("1 - eps: measures[1] unit", MeasureUnit::getInch().getIdentifier(),
                  measures2[1]->getUnit().getIdentifier());
+
+    // TODO(icu-units#63): test negative numbers!
 }
 
 /**

--- a/icu4c/source/test/intltest/unitstest.cpp
+++ b/icu4c/source/test/intltest/unitstest.cpp
@@ -462,6 +462,24 @@ void UnitsTest::testComplexUnitConverter() {
     assertEquals("1 - eps: measures[1] unit", MeasureUnit::getInch().getIdentifier(),
                  measures2[1]->getUnit().getIdentifier());
 
+    input = MeasureUnit::getLightYear();
+    output = MeasureUnit::forIdentifier("light-year-and-kilometer", status);
+    // TODO: reusing tempInput and tempOutput results in a leak.
+    MeasureUnitImpl tempInput3, tempOutput3;
+    const MeasureUnitImpl &inputImpl3 = MeasureUnitImpl::forMeasureUnit(input, tempInput3, status);
+    const MeasureUnitImpl &outputImpl3 = MeasureUnitImpl::forMeasureUnit(output, tempOutput3, status);
+    // TODO: reusing converter results in a leak.
+    ComplexUnitsConverter converter3 = ComplexUnitsConverter(inputImpl3, outputImpl3, rates, status);
+    // TODO: reusing measures results in a leak.
+    MaybeStackVector<Measure> measures3 = converter3.convert((2.0 - DBL_EPSILON), status);
+    assertEquals("measures length", 2, measures3.length());
+    assertEquals("light-year test: measures[0] value", 2.0, measures3[0]->getNumber().getDouble(status));
+    assertEquals("light-year test: measures[0] unit", MeasureUnit::getLightYear().getIdentifier(),
+                 measures3[0]->getUnit().getIdentifier());
+    assertEquals("light-year test: measures[1] value", 0.0, measures3[1]->getNumber().getDouble(status));
+    assertEquals("light-year test: measures[1] unit", MeasureUnit::getKilometer().getIdentifier(),
+                 measures3[1]->getUnit().getIdentifier());
+
     // TODO(icu-units#63): test negative numbers!
 }
 

--- a/icu4c/source/test/intltest/unitstest.cpp
+++ b/icu4c/source/test/intltest/unitstest.cpp
@@ -503,7 +503,7 @@ void UnitsTest::testComplexUnitsConverter() {
                  measures4[1]->getUnit().getIdentifier());
 
     // 2e-16 light years is 1.892146 meters. We consider this in the noise, and
-    // thus expect a 0.
+    // thus expect a 0. (This test fails when 2e-16 is increased to 4e-16.)
     MaybeStackVector<Measure> measures5 = converter3.convert((1.0 + 2e-16), status);
     assertEquals("measures length", 2, measures5.length());
     assertEquals("light-year test: measures[0] value", 1.0, measures5[0]->getNumber().getDouble(status));


### PR DESCRIPTION
Use DBL_EPSILON appropriately.

<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [ ] Issue filed: https://unicode-org.atlassian.net/browse/ICU-_____
- [ ] Updated PR title and link in previous line to include Issue number
- [ ] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

