### PR TITLE
Add protected MaybeStackArray::copyFrom()

### DIFF
--- a/icu4c/source/common/cmemory.h
+++ b/icu4c/source/common/cmemory.h
@@ -388,11 +388,22 @@ public:
      */
     inline T *orphanOrClone(int32_t length, int32_t &resultCapacity);
 
-  protected: // TODO(icu-units#64): make these private again if possible?
+protected:
+    // Resizes the array to the size of src, then copies the contents of src.
+    void copyFrom(const MaybeStackArray &src, UErrorCode &status) {
+        if (U_FAILURE(status)) {
+            return;
+        }
+        if (this->resize(src.capacity, 0) == NULL) {
+            status = U_INDEX_OUTOFBOUNDS_ERROR;
+            return;
+        }
+        uprv_memcpy(this->ptr, src.ptr, (size_t)capacity * sizeof(T));
+    }
+
+private:
     T *ptr;
     int32_t capacity;
-
-  private:
     UBool needToRelease;
     T stackArray[stackCapacity];
     void releaseArray() {

--- a/icu4c/source/common/cmemory.h
+++ b/icu4c/source/common/cmemory.h
@@ -395,7 +395,7 @@ protected:
             return;
         }
         if (this->resize(src.capacity, 0) == NULL) {
-            status = U_INDEX_OUTOFBOUNDS_ERROR;
+            status = U_MEMORY_ALLOCATION_ERROR;
             return;
         }
         uprv_memcpy(this->ptr, src.ptr, (size_t)capacity * sizeof(T));

--- a/icu4c/source/i18n/number_microprops.h
+++ b/icu4c/source/i18n/number_microprops.h
@@ -54,13 +54,7 @@ class IntMeasures : public MaybeStackArray<int64_t, 2> {
         if (this == &rhs) {
             return *this;
         }
-        int32_t length = rhs.capacity;
-        if (this->resize(length, 0) != NULL) {
-            U_ASSERT(this->capacity == rhs.capacity);
-            uprv_memcpy(this->ptr, rhs.ptr, (size_t)length * sizeof(int64_t));
-        } else {
-            status = U_MEMORY_ALLOCATION_ERROR;
-        }
+        copyFrom(rhs, status);
         return *this;
     }
 


### PR DESCRIPTION
Closes #64: removes the need to expose ptr and capacity to subclasses.

I'm being conservative and making copyFrom a protected method.

<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [ ] Issue filed: https://unicode-org.atlassian.net/browse/ICU-_____
- [ ] Updated PR title and link in previous line to include Issue number
- [ ] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

