### PR TITLE
ICU-20568 Have macrosToMicroGenerator do input unit calculation.

### DIFF
--- a/icu4c/source/i18n/number_formatimpl.cpp
+++ b/icu4c/source/i18n/number_formatimpl.cpp
@@ -250,7 +250,9 @@ NumberFormatterImpl::macrosToMicroGenerator(const MacroProps& macros, bool safe,
         fUsagePrefsHandler.adoptInsteadAndCheckErrorCode(usagePrefsHandler, status);
         chain = fUsagePrefsHandler.getAlias();
     } else if (isMixedUnit) {
-        auto unitConversionHandler = new UnitConversionHandler(macros.unit, chain, status);
+        int32_t outCount;
+        LocalArray<MeasureUnit> singleUnits = macros.unit.splitToSingleUnits(outCount, status);
+        auto unitConversionHandler = new UnitConversionHandler(singleUnits[0], macros.unit, chain, status);
         fUnitConversionHandler.adoptInsteadAndCheckErrorCode(unitConversionHandler, status);
         chain = fUnitConversionHandler.getAlias();
     }

--- a/icu4c/source/i18n/number_usageprefs.cpp
+++ b/icu4c/source/i18n/number_usageprefs.cpp
@@ -183,21 +183,14 @@ Precision UsagePrefsHandler::parseSkeletonToPrecision(icu::UnicodeString precisi
     return macros.precision;
 }
 
-UnitConversionHandler::UnitConversionHandler(const MeasureUnit &unit, const MicroPropsGenerator *parent,
-                                             UErrorCode &status)
-    : fOutputUnit(unit), fParent(parent) {
-    MeasureUnitImpl temp;
-    const MeasureUnitImpl &outputUnit = MeasureUnitImpl::forMeasureUnit(unit, temp, status);
-    const MeasureUnitImpl *inputUnit = &outputUnit;
-    MaybeStackVector<MeasureUnitImpl> singleUnits;
-    U_ASSERT(outputUnit.complexity == UMEASURE_UNIT_MIXED);
-    // When we wish to support unit conversion, replace the above assert with this if:
-    // if (outputUnit.complexity == UMEASURE_UNIT_MIXED) {
-    {
-        singleUnits = outputUnit.extractIndividualUnits(status);
-        U_ASSERT(singleUnits.length() > 0);
-        inputUnit = singleUnits[0];
-    }
+UnitConversionHandler::UnitConversionHandler(const MeasureUnit &inputUnit, const MeasureUnit &outputUnit,
+                                             const MicroPropsGenerator *parent, UErrorCode &status)
+    : fOutputUnit(outputUnit), fParent(parent) {
+    MeasureUnitImpl tempInput, tempOutput;
+    const MeasureUnitImpl &inputUnitImpl = MeasureUnitImpl::forMeasureUnit(inputUnit, tempInput, status);
+    const MeasureUnitImpl &outputUnitImpl =
+        MeasureUnitImpl::forMeasureUnit(outputUnit, tempOutput, status);
+
     // TODO: this should become an initOnce thing? Review with other
     // ConversionRates usages.
     ConversionRates conversionRates(status);
@@ -205,7 +198,7 @@ UnitConversionHandler::UnitConversionHandler(const MeasureUnit &unit, const Micr
         return;
     }
     fUnitConverter.adoptInsteadAndCheckErrorCode(
-        new ComplexUnitsConverter(*inputUnit, outputUnit, conversionRates, status), status);
+        new ComplexUnitsConverter(inputUnitImpl, outputUnitImpl, conversionRates, status), status);
 }
 
 void UnitConversionHandler::processQuantity(DecimalQuantity &quantity, MicroProps &micros,

--- a/icu4c/source/i18n/number_usageprefs.h
+++ b/icu4c/source/i18n/number_usageprefs.h
@@ -90,22 +90,23 @@ namespace number {
 namespace impl {
 
 /**
- * A MicroPropsGenerator which converts a measurement from a simple MeasureUnit
- * to a Mixed MeasureUnit.
+ * A MicroPropsGenerator which converts a measurement from one MeasureUnit to
+ * another. In particular, the output MeasureUnit may be a mixed unit. (The
+ * input unit may not be a mixed unit.)
  */
 class U_I18N_API UnitConversionHandler : public MicroPropsGenerator, public UMemory {
   public:
     /**
      * Constructor.
      *
-     * @param unit Specifies both the input and output MeasureUnit: if it is a
-     *     MIXED unit, the input MeasureUnit will be just the biggest unit of
-     *     the sequence.
+     * @param inputUnit Specifies the input MeasureUnit. Mixed units are not
+     *     supported as input (because input is just a single decimal quantity).
+     * @param outputUnit Specifies the output MeasureUnit.
      * @param parent The parent MicroPropsGenerator.
      * @param status Receives status.
      */
-    UnitConversionHandler(const MeasureUnit &unit, const MicroPropsGenerator *parent,
-                          UErrorCode &status);
+    UnitConversionHandler(const MeasureUnit &inputUnit, const MeasureUnit &outputUnit,
+                          const MicroPropsGenerator *parent, UErrorCode &status);
 
     /**
      * Obtains the appropraite output values from the Unit Converter.

--- a/icu4c/source/i18n/unicode/measunit.h
+++ b/icu4c/source/i18n/unicode/measunit.h
@@ -447,7 +447,7 @@ class U_I18N_API MeasureUnit: public UObject {
 
 #ifndef U_HIDE_INTERNAL_API
     /**
-     * Gets the list of SINGLE units contained within a MIXED of COMPOUND unit.
+     * Gets the list of SINGLE units contained within a MIXED or COMPOUND unit.
      *
      * Examples:
      * - Given "meter-kilogram-per-second", three units will be returned: "meter",


### PR DESCRIPTION
This moves input unit calculation out of UnitConversionHandler making
it simpler and clearer, and localises the "MacroProps interpretation"
work in macrosToMicroGenerator, where it belongs.

<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [ ] Issue filed: https://unicode-org.atlassian.net/browse/ICU-_____
- [ ] Updated PR title and link in previous line to include Issue number
- [ ] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

